### PR TITLE
Fix getRouteOption + only handle master requests

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,7 +17,8 @@ services:
         class: %mobile_detect.request_listener.class%
         arguments: [ '@service_container', %mobile_detect.redirect%, %mobile_detect.switch_device_view.save_referer_path% ]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: handleRequest }
+            # must be registered after the Router to have access to the _route, and after the Symfony LocaleListener
+            - { name: kernel.event_listener, event: kernel.request, method: handleRequest, priority: 1 }
             - { name: kernel.event_listener, event: kernel.response, method: handleResponse }
     mobile_detect.twig.extension:
       class: %mobile_detect.twig.extension.class%


### PR DESCRIPTION
- the Symfony RouteCollection can return null if a Route object is not found, this is fixed
- if fe. esi is used twig will return an error for sub request, therefore only handle master request
- upped the priority a bit of the kernel.request listener to be called before content is rendered
