### PR TITLE
Fixes #50: Query string gets lost on "device_view=XXX"

### DIFF
--- a/EventListener/RequestListener.php
+++ b/EventListener/RequestListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Request listener
@@ -264,8 +265,16 @@ class RequestListener
     protected function getRedirectResponseBySwitchParam()
     {
         if (true === $this->isFullPath) {
+            /* @var $request Request */
             $request = $this->container->get('request');
             $redirectUrl = $request->getUriForPath($request->getPathInfo());
+            $queryParams = $request->query->all();
+            if (array_key_exists('device_view', $queryParams)) {
+                unset($queryParams['device_view']);
+            }
+            if(sizeof($queryParams) > 0) {
+                $redirectUrl .= '?'. Request::normalizeQueryString(http_build_query($queryParams));
+            }
         } else {
             $redirectUrl = $this->getCurrentHost();
         }

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
  * Request Listener Test
@@ -117,8 +118,13 @@ class RequestListenerTest extends PHPUnit_Framework_TestCase
     public function handleRequestHasSwitchParam()
     {
         $listener = new RequestListener($this->serviceContainer, array());
+        $this->request->query = new ParameterBag(array('myparam'=>'myvalue','device_view'=>'mobile'));
         $this->deviceView->expects($this->once())->method('hasSwitchParam')->will($this->returnValue(true));
-        $this->deviceView->expects($this->once())->method('getRedirectResponseBySwitchParam')->will($this->returnValue($this->getMock('Symfony\Component\HttpFoundation\Response')));
+        $this->deviceView
+            ->expects($this->once())
+            ->method('getRedirectResponseBySwitchParam')
+            ->with($this->stringEndsWith('?myparam=myvalue'))
+            ->will($this->returnValue($this->getMock('Symfony\Component\HttpFoundation\Response')));
         $event = $this->createGetResponseEvent('some content');
 
         $listener->handleRequest($event);


### PR DESCRIPTION
This fixes #50: Query string gets lost on "device_view=XXX". Feedback welcome, pull too :)
