### PR TITLE
Fix Travis build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "mobiledetect/mobiledetectlib": "2.7.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "~4.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Updates the phpunit version to ~4.1, which should fix Travis builds breaking on PHP versions > 5.3.
See: http://www.serverphorums.com/read.php?7,946926 and https://github.com/sebastianbergmann/phpunit-mock-objects/commit/1c68f1338f1940deb8265428bb2a7cbc5bc074b5#diff-64dbbc1c21f9be2d92e2b715617ffe34
