### PR TITLE
Update MobileDetector user agent after master request

### DIFF
--- a/EventListener/RequestListener.php
+++ b/EventListener/RequestListener.php
@@ -75,6 +75,8 @@ class RequestListener
             return;
         }
 
+        $this->mobileDetector->setUserAgent($event->getRequest()->headers->get('user-agent'));
+
         // Sets the flag for the response handled by the GET switch param and the type of the view.
         if ($this->deviceView->hasSwitchParam()) {
             $event->setResponse($this->getRedirectResponseBySwitchParam());

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -388,6 +388,20 @@ class RequestListenerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function handleRequestUpdatedMobileDetectorUserAgent()
+    {
+        $this->mobileDetector->expects($this->once())->method('setUserAgent')->with($this->equalTo('agent'));
+
+        $event = $this->createGetResponseEvent('some content');
+        $event->getRequest()->headers->set('user-agent', 'agent');
+
+        $listener = new RequestListener($this->serviceContainer, $this->config);
+        $listener->handleRequest($event);
+    }
+
+    /**
      * createRouteCollecitonWithRouteAndRoutingOption
      *
      * @param type $returnValue Return value


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Hello, please let me know if I do something wrong here.

I had problems running Symfony functional tests with MobileDetectBundle. All requests I make are using user-agent `Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36` (android nexus 7), I checked and user-agent is correctly set in $request in headers, server request parameter bag. When I do multiple requests in one functional test, then i get correct device from `MobileDetect` only for first request, for all subsequent requests it returns `is_tablet() == false; // true`

This PR fixes this issue, it sets user-agent in `MobileDetech` for each master request.

I can add functional test that simulates the problem as well, but I wanted to know if I am doing stuff right first, because to do functional test I would have to set up symfony environment to test this bundle.

Thank you for your work on this bundle, helped me a lot :-)
