### PR TITLE
Lessen requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/framework-bundle": ">=2.3,<3.0",
-        "mobiledetect/mobiledetectlib": "2.8.*"
+        "mobiledetect/mobiledetectlib": "~2.8"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"


### PR DESCRIPTION
Hi,

At the moment, the bundle is requiring "exact" versions of MobileDetect library, such as `2.7.*`.
Such a precise requirement can cause issues: for instance, if in my project I have this bundle version 0.9, I can't just do `composer update suncat/mobile-detect-bundle` to go to 0.10. Because I need to also update `mobiledetect/mobiledetectlib`, but the strict requirement is forbidding this.

A best practice (for reusable bundles) is to use `~` operator: it means "at least this version, or upper, but not next incompatible one". So using `"mobiledetect/mobiledetectlib": "~ 2.8"` would require at least 2.8 (though may be we could accommodate smaller?), and anything but `3.0` (as according to semver would break things).

Issue solved, and you won't need anymore to update this bundle each time MobileDetect is releasing a new minor version too!