### PR TITLE
Remove conflicted namespace

### DIFF
--- a/EventListener/RequestListener.php
+++ b/EventListener/RequestListener.php
@@ -19,7 +19,6 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
 use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
-use Doctrine\Tests\Common\Annotations\True;
 
 /**
  * Request listener


### PR DESCRIPTION
When using PHP 7 beta I am getting this error:

FatalErrorException in RequestListener.php line 22:
Compile Error: Cannot use Doctrine\Tests\Common\Annotations\True as True because 'True' is a special class name

Looks like this namespace is not used as well.