### PR TITLE
improve the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,32 @@
+sudo: false
+
 language:
   - php
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.0
+  - hhvm
 
-env:
-  - SYMFONY_VERSION=2.1.*
-  - SYMFONY_VERSION=2.2.*
-  - SYMFONY_VERSION=2.3.*
-  - SYMFONY_VERSION=2.4.*
+matrix:
+  include:
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: COVERAGE=yes
 
 before_script:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION}
-  - composer update --dev
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}; fi
+  - composer install
+  - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
 
 script:
-  - phpunit --coverage-text
+  - if [ "$COVERAGE" = "yes" ]; then ./vendor/bin/phpunit --coverage-text; else ./vendor/bin/phpunit; fi

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -64,7 +64,10 @@ class RequestListenerTest extends PHPUnit_Framework_TestCase
 
         $this->mobileDetector = $this->getMockBuilder('SunCat\MobileDetectBundle\DeviceDetector\MobileDetector')->disableOriginalConstructor()->getMock();
         $this->deviceView = $this->getMockBuilder('SunCat\MobileDetectBundle\Helper\DeviceView')->disableOriginalConstructor()->getMock();
-        $this->router = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Routing\Router')->disableOriginalConstructor()->getMock();
+        $this->router = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Routing\Router')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRouteCollection'))
+            ->getMock();
 
         $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
         $this->request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "mobiledetect/mobiledetectlib": "~2.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.1|~5.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
* use the faster container based infrastructure
* preserve the Composer cache between builds
* add jobs for PHP 5.5, 5.6, 7.0 and HHVM
* drop jobs for unsupported Symfony versions (the bundle actually
  requires version 2.3 or higher of the FrameworkBundle)
* drop job with Symfony 2.4 which reached its end of life a long time
  ago
* add a job with Symfony 2.7
* reduce the size of the build matrix by running tests with different
  Symfony versions only with PHP 5.6
* don't generate code coverage report in every job