### PR TITLE
make it  not dependent on a sepecific device detector implementation

### DIFF
--- a/DeviceDetector/DeviceDetectorInterface.php
+++ b/DeviceDetector/DeviceDetectorInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the MobileDetectBundle.
+ *
+ * (c) Nikolay Ivlev <nikolay.kotovsky@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SunCat\MobileDetectBundle\DeviceDetector;
+
+/**
+ *
+ * @author vidy videni <vidy.videni@gmail.com>
+ *
+ */
+interface DeviceDetectorInterface
+{
+
+    /**
+     * Set the User-Agent to be used.
+     *
+     * @param string $userAgent The user agent string to set.
+     *
+     * @return string|null
+     */
+    public function setUserAgent($userAgent);
+
+    /**
+     * @return boolean
+     */
+    public function isTablet();
+
+    /**
+     * @return boolean
+     */
+    public function isMobile();
+    
+    /**
+     * Is device
+     * @param string $deviceName is[iPhone|BlackBerry|HTC|Nexus|Dell|Motorola|Samsung|Sony|Asus|Palm|Vertu|...]
+     *
+     * @return boolean
+     */
+    public function isDevice($deviceName);
+}

--- a/DeviceDetector/MobileDetector.php
+++ b/DeviceDetector/MobileDetector.php
@@ -19,6 +19,16 @@ use Detection\MobileDetect;
  * @author suncat2000 <nikolay.kotovsky@gmail.com>
  *
  */
-class MobileDetector extends MobileDetect
+class MobileDetector extends MobileDetect  implements  DeviceDetectorInterface
 {
+
+    /**
+     * @inheritdoc
+     */
+    public function isDevice($deviceName)
+    {
+        $magicMethodName = 'is' . strtolower((string) $deviceName);
+
+        return $this->$magicMethodName();
+    }
 }

--- a/EventListener/RequestResponseListener.php
+++ b/EventListener/RequestResponseListener.php
@@ -11,7 +11,6 @@
 
 namespace SunCat\MobileDetectBundle\EventListener;
 
-use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -19,6 +18,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
+use  SunCat\MobileDetectBundle\DeviceDetector\DeviceDetectorInterface;
 
 /**
  * Request and response listener
@@ -37,9 +37,9 @@ class RequestResponseListener
     CONST FULL      = 'full';
 
     /**
-     * @var MobileDetector
+     * @var DeviceDetectorInterface
      */
-    protected $mobileDetector;
+    protected $deviceDetector;
 
     /**
      * @var DeviceView
@@ -69,21 +69,21 @@ class RequestResponseListener
     /**
      * RequestResponseListener constructor.
      *
-     * @param MobileDetector  $mobileDetector
+     * @param DeviceDetectorInterface  $deviceDetector
      * @param DeviceView      $deviceView
      * @param RouterInterface $router
      * @param array           $redirectConf
      * @param bool            $fullPath
      */
     public function __construct(
-        MobileDetector $mobileDetector,
+        DeviceDetectorInterface $deviceDetector,
         DeviceView $deviceView,
         RouterInterface $router,
         array $redirectConf,
         $fullPath = true
     )
     {
-        $this->mobileDetector = $mobileDetector;
+        $this->deviceDetector = $deviceDetector;
         $this->deviceView = $deviceView;
         $this->router = $router;
 
@@ -108,7 +108,7 @@ class RequestResponseListener
         }
 
         $request = $event->getRequest();
-        $this->mobileDetector->setUserAgent($request->headers->get('user-agent'));
+        $this->deviceDetector->setUserAgent($request->headers->get('user-agent'));
 
         // Sets the flag for the response handled by the GET switch param and the type of the view.
         if ($this->deviceView->hasSwitchParam()) {
@@ -119,9 +119,9 @@ class RequestResponseListener
         // If neither the SwitchParam nor the cookie are set, detect the view...
         $cookieIsSet = $this->deviceView->getRequestedViewType() !== null;
         if (!$cookieIsSet) {
-            if ($this->redirectConf['detect_tablet_as_mobile'] === false && $this->mobileDetector->isTablet()) {
+            if ($this->redirectConf['detect_tablet_as_mobile'] === false && $this->deviceDetector->isTablet()) {
                 $this->deviceView->setTabletView();
-            } elseif ($this->mobileDetector->isMobile()) {
+            } elseif ($this->deviceDetector->isMobile()) {
                 $this->deviceView->setMobileView();
             } else {
                 $this->deviceView->setFullView();

--- a/Twig/Extension/MobileDetectExtension.php
+++ b/Twig/Extension/MobileDetectExtension.php
@@ -11,7 +11,7 @@
 
 namespace SunCat\MobileDetectBundle\Twig\Extension;
 
-use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
+use SunCat\MobileDetectBundle\DeviceDetector\DeviceDetectorInterface;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -24,9 +24,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
-     * @var \SunCat\MobileDetectBundle\DeviceDetector\MobileDetector
+     * @var \SunCat\MobileDetectBundle\DeviceDetector\DeviceDetectorInterface
      */
-    private $mobileDetector;
+    private $deviceDetector;
     
     /**
      * @var \SunCat\MobileDetectBundle\Helper\DeviceView
@@ -46,13 +46,13 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
     /**
      * MobileDetectExtension constructor.
      * 
-     * @param MobileDetector $mobileDetector
+     * @param DeviceDetectorInterface $deviceDetector
      * @param DeviceView $deviceView
      * @param array $redirectConf
      */
-    public function __construct(MobileDetector $mobileDetector, DeviceView $deviceView, array $redirectConf)
+    public function __construct(DeviceDetectorInterface $deviceDetector, DeviceView $deviceView, array $redirectConf)
     {
-        $this->mobileDetector = $mobileDetector;
+        $this->deviceDetector = $deviceDetector;
         $this->deviceView = $deviceView;
         $this->redirectConf = $redirectConf;
     }
@@ -123,7 +123,7 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
      */
     public function isMobile()
     {
-        return $this->mobileDetector->isMobile();
+        return $this->deviceDetector->isMobile();
     }
 
     /**
@@ -132,20 +132,7 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
      */
     public function isTablet()
     {
-        return $this->mobileDetector->isTablet();
-    }
-
-    /**
-     * Is device
-     * @param string $deviceName is[iPhone|BlackBerry|HTC|Nexus|Dell|Motorola|Samsung|Sony|Asus|Palm|Vertu|...]
-     *
-     * @return boolean
-     */
-    public function isDevice($deviceName)
-    {
-        $magicMethodName = 'is' . strtolower((string) $deviceName);
-
-        return $this->mobileDetector->$magicMethodName();
+        return $this->deviceDetector->isTablet();
     }
 
     /**
@@ -195,7 +182,7 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
      */
     public function isIOS()
     {
-        return $this->mobileDetector->isIOS();
+        return $this->deviceDetector->isDevice('IOS');
     }
 
     /**
@@ -205,7 +192,7 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
      */
     public function isAndroidOS()
     {
-        return $this->mobileDetector->isAndroidOS();
+        return $this->deviceDetector->isDevice('AndroidOS');
     }
 
     /**


### PR DESCRIPTION
this bundle would be better if it doesn't depend on   `mobiledetect/mobiledetectlib` , `piwik/device-detector` is also a good alternative,  I create a bridge to connect `piwik/device-detector` to this bundle,please follow this link [videni/piwik-device-detector-bridge](https://github.com/videni/piwik-device-detector-bridge), still there is a  problems  , the isDevice method of the two libraries behave differently, but this will not hurt this bundle.     the MobileDetectExtensionTest is failed , because there is no __call method in DeviceDetectorInterface  . 
