### PR TITLE
Remove typehint to allow MobileDetector override

### DIFF
--- a/EventListener/RequestResponseListener.php
+++ b/EventListener/RequestResponseListener.php
@@ -11,7 +11,6 @@
 
 namespace SunCat\MobileDetectBundle\EventListener;
 
-use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -37,7 +36,7 @@ class RequestResponseListener
     CONST FULL      = 'full';
 
     /**
-     * @var MobileDetector
+     * @var mixed
      */
     protected $mobileDetector;
 
@@ -69,14 +68,14 @@ class RequestResponseListener
     /**
      * RequestResponseListener constructor.
      *
-     * @param MobileDetector  $mobileDetector
+     * @param mixed           $mobileDetector
      * @param DeviceView      $deviceView
      * @param RouterInterface $router
      * @param array           $redirectConf
      * @param bool            $fullPath
      */
     public function __construct(
-        MobileDetector $mobileDetector,
+        $mobileDetector,
         DeviceView $deviceView,
         RouterInterface $router,
         array $redirectConf,

--- a/Twig/Extension/MobileDetectExtension.php
+++ b/Twig/Extension/MobileDetectExtension.php
@@ -11,7 +11,6 @@
 
 namespace SunCat\MobileDetectBundle\Twig\Extension;
 
-use SunCat\MobileDetectBundle\DeviceDetector\MobileDetector;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -21,10 +20,10 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *
  * @author suncat2000 <nikolay.kotovsky@gmail.com>
  */
-class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class MobileDetectExtension extends \Twig_Extension
 {
     /**
-     * @var \SunCat\MobileDetectBundle\DeviceDetector\MobileDetector
+     * @var mixed
      */
     private $mobileDetector;
     
@@ -46,11 +45,11 @@ class MobileDetectExtension extends \Twig_Extension implements \Twig_Extension_G
     /**
      * MobileDetectExtension constructor.
      * 
-     * @param MobileDetector $mobileDetector
+     * @param mixed $mobileDetector
      * @param DeviceView $deviceView
      * @param array $redirectConf
      */
-    public function __construct(MobileDetector $mobileDetector, DeviceView $deviceView, array $redirectConf)
+    public function __construct($mobileDetector, DeviceView $deviceView, array $redirectConf)
     {
         $this->mobileDetector = $mobileDetector;
         $this->deviceView = $deviceView;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.5.0",
         "symfony/framework-bundle": "~2.4|~3.0",
         "mobiledetect/mobiledetectlib": "~2.8",
-        "twig/twig": "~1.23"
+        "twig/twig": "~1.23|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
With the hardcoded typehint it not possible to override the default `MobileDetector` class.
A nicer way would be to define an interface, but that can come later.

Also added twig 2.0 dependency as it works with it.