### PR TITLE
Remove strick on request_stack

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="mobile_detect.device_view" />
             <argument>%mobile_detect.redirect%</argument>
             <call method="setRequestByRequestStack">
-                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+                <argument type="service" id="request_stack" on-invalid="null" />
             </call>
             <tag name="twig.extension"/>
         </service>


### PR DESCRIPTION
Hi all,

The "strict" attribute used when referencing the "request_stack" service is deprecated since version 3.3 and will be removed in 4.0.

best.