### PR TITLE
Fix code style (Symfony2) and remove twig deprecated method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,33 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.5
   - 5.6
   - hhvm
   - 7.0
+
+dist: trusty
 
 matrix:
   allow_failures:
     - php: hhvm
   fast_finish: true
   include:
-    - php: 5.5
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION='2.4.*'
-    - php: 5.5
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_VERSION='2.8.*'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.4.*'
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'
     - php: 5.6
       env: SYMFONY_VERSION='3.0.*'
+    - php: 5.6
+      env: SYMFONY_VERSION='3.2.*'
+    - php: 5.6
+      env: SYMFONY_VERSION='3.3.*'
     - php: 7.0
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.0
       env: SYMFONY_VERSION='3.0.*'
+    - php: 7.0
+      env: SYMFONY_VERSION='3.2.*'
+    - php: 7.0
+      env: SYMFONY_VERSION='3.3.*'
 
 
 before_install:

--- a/Tests/Twig/Extension/MobileDetectExtensionTest.php
+++ b/Tests/Twig/Extension/MobileDetectExtensionTest.php
@@ -377,15 +377,4 @@ class MobileDetectExtensionTest extends PHPUnit_Framework_TestCase
         $extension = new MobileDetectExtension($this->mobileDetector, $deviceView, $this->config);
         $this->assertFalse($extension->isAndroidOS());
     }
-
-    /**
-     * @test
-     */
-    public function getNameTwigExtension()
-    {
-        $deviceView = new DeviceView($this->requestStack);
-        $extension = new MobileDetectExtension($this->mobileDetector, $deviceView, $this->config);
-        $this->assertEquals('mobile_detect.twig.extension', $extension->getName());
-    }
-
 }

--- a/Twig/Extension/MobileDetectExtension.php
+++ b/Twig/Extension/MobileDetectExtension.php
@@ -27,7 +27,7 @@ class MobileDetectExtension extends \Twig_Extension
      * @var \SunCat\MobileDetectBundle\DeviceDetector\MobileDetector
      */
     private $mobileDetector;
-    
+
     /**
      * @var \SunCat\MobileDetectBundle\Helper\DeviceView
      */
@@ -45,10 +45,10 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * MobileDetectExtension constructor.
-     * 
+     *
      * @param MobileDetector $mobileDetector
-     * @param DeviceView $deviceView
-     * @param array $redirectConf
+     * @param DeviceView     $deviceView
+     * @param array          $redirectConf
      */
     public function __construct(MobileDetector $mobileDetector, DeviceView $deviceView, array $redirectConf)
     {
@@ -59,6 +59,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Get extension twig function
+     *
      * @return array
      */
     public function getFunctions()
@@ -73,7 +74,7 @@ class MobileDetectExtension extends \Twig_Extension
             new \Twig_SimpleFunction('is_not_mobile_view', array($this, 'isNotMobileView')),
             new \Twig_SimpleFunction('is_ios', array($this, 'isIOS')),
             new \Twig_SimpleFunction('is_android_os', array($this, 'isAndroidOS')),
-            new \Twig_SimpleFunction('full_view_url', array($this, 'fullViewUrl'), array('is_safe' => array('html')))
+            new \Twig_SimpleFunction('full_view_url', array($this, 'fullViewUrl'), array('is_safe' => array('html'))),
         );
     }
 
@@ -82,6 +83,9 @@ class MobileDetectExtension extends \Twig_Extension
      * in the full/desktop view. This is useful for generating <link rel="canonical"> tags
      * on mobile pages for Search Engine Optimization.
      * See: http://searchengineland.com/the-definitive-guide-to-mobile-technical-seo-166066
+     *
+     * @param boolean $addCurrentPathAndQuery
+     *
      * @return string
      */
     public function fullViewUrl($addCurrentPathAndQuery = true)
@@ -101,17 +105,17 @@ class MobileDetectExtension extends \Twig_Extension
         if (!$this->request) {
             return $fullHost;
         }
-        
+
         if (false === $addCurrentPathAndQuery) {
             return $fullHost;
         }
 
         // if fullHost ends with /, skip it since getPathInfo() also starts with /
-        $result = rtrim($fullHost, '/') . $this->request->getPathInfo();
+        $result = rtrim($fullHost, '/').$this->request->getPathInfo();
 
         $query = Request::normalizeQueryString(http_build_query($this->request->query->all(), null, '&'));
         if ($query) {
-            $result .= '?' . $query;
+            $result .= '?'.$query;
         }
 
         return $result;
@@ -119,6 +123,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is mobile
+     *
      * @return boolean
      */
     public function isMobile()
@@ -128,6 +133,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is tablet
+     *
      * @return boolean
      */
     public function isTablet()
@@ -137,20 +143,21 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is device
+     *
      * @param string $deviceName is[iPhone|BlackBerry|HTC|Nexus|Dell|Motorola|Samsung|Sony|Asus|Palm|Vertu|...]
      *
      * @return boolean
      */
     public function isDevice($deviceName)
     {
-        $magicMethodName = 'is' . strtolower((string) $deviceName);
+        $magicMethodName = 'is'.strtolower((string) $deviceName);
 
         return $this->mobileDetector->$magicMethodName();
     }
 
     /**
      * Is full view type
-     * 
+     *
      * @return boolean
      */
     public function isFullView()
@@ -160,7 +167,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is mobile view type
-     * 
+     *
      * @return boolean
      */
     public function isMobileView()
@@ -170,7 +177,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is tablet view type
-     * 
+     *
      * @return boolean
      */
     public function isTabletView()
@@ -180,7 +187,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is not mobile view type
-     * 
+     *
      * @return boolean
      */
     public function isNotMobileView()
@@ -190,7 +197,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is iOS
-     * 
+     *
      * @return boolean
      */
     public function isIOS()
@@ -200,7 +207,7 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Is Android OS
-     * 
+     *
      * @return boolean
      */
     public function isAndroidOS()
@@ -210,20 +217,13 @@ class MobileDetectExtension extends \Twig_Extension
 
     /**
      * Sets the request from the current scope.
-     * @param Request $request
+     *
+     * @param RequestStack $requestStack
      */
-    public function setRequestByRequestStack(RequestStack $requestStack = null) {
+    public function setRequestByRequestStack(RequestStack $requestStack = null)
+    {
         if (null !== $requestStack) {
             $this->request = $requestStack->getMasterRequest();
         }
-    }
-
-    /**
-     * Extension name
-     * @return string
-     */
-    public function getName()
-    {
-        return 'mobile_detect.twig.extension';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "symfony/framework-bundle": "~2.4|~3.0",
+        "php": ">=5.5.9",
+        "symfony/framework-bundle": "~2.7|~3.3",
         "mobiledetect/mobiledetectlib": "~2.8",
         "twig/twig": "~1.23|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/phpunit-bridge": "~2.7|~3.3",
         "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Hi all,

The method getName of twig extension is deprecated since Twig 1.26 (to be removed in Twig 2.0).

I propose some small modifications on code to fit the phpcs Symfony2 rules.

best.