### PR TITLE
require a compatible Twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.5.9",
         "symfony/framework-bundle": "~2.7|~3.3",
         "mobiledetect/mobiledetectlib": "~2.8",
-        "twig/twig": "~1.23|~2.0"
+        "twig/twig": "~1.26|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
since the removal of the `getName()` method in #111 the bundle requires
Twig version 1.26 or higher