### PR TITLE
fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install: composer update $COMPOSER_FLAGS --dev --no-interaction --prefer-dist
 
 script:
   - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then mkdir -p build/logs; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then phpunit --coverage-clover build/logs/clover.xml; else phpunit; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
 
 after_script:
   - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php vendor/bin/coveralls -v; fi

--- a/Tests/DataCollector/DeviceDataCollectorTest.php
+++ b/Tests/DataCollector/DeviceDataCollectorTest.php
@@ -11,7 +11,7 @@
 
 namespace SunCat\MobileDetectBundle\Tests\DataCollector;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use SunCat\MobileDetectBundle\DataCollector\DeviceDataCollector;
 use SunCat\MobileDetectBundle\EventListener\RequestResponseListener;
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\ServerBag;
  *
  * @author suncat2000 <nikolay.kotovsky@gmail.com>
  */
-class DeviceDataCollectorTest extends PHPUnit_Framework_TestCase
+class DeviceDataCollectorTest extends TestCase
 {
     /**
      * @var PHPUnit_Framework_MockObject_MockBuilder

--- a/Tests/DependencyInjection/MobileDetectExtensionTest.php
+++ b/Tests/DependencyInjection/MobileDetectExtensionTest.php
@@ -11,8 +11,8 @@
 
 namespace SunCat\MobileDetectBundle\Tests\DependencyInjection;
 
-use PHPUnit_Framework_TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
+use PHPUnit\Framework\TestCase;
 use SunCat\MobileDetectBundle\DependencyInjection\MobileDetectExtension;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author suncat2000 <nikolay.kotovsky@gmail.com>
  */
-class MobileDetectExtensionTest extends PHPUnit_Framework_TestCase
+class MobileDetectExtensionTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/EventListener/RequestResponseListenerTest.php
+++ b/Tests/EventListener/RequestResponseListenerTest.php
@@ -2,7 +2,7 @@
 
 namespace SunCat\MobileDetectBundle\Tests\RequestListener;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use SunCat\MobileDetectBundle\EventListener\RequestResponseListener;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 /**
  * Request and Response Listener Test
  */
-class RequestResponseListenerTest extends PHPUnit_Framework_TestCase
+class RequestResponseListenerTest extends TestCase
 {
 
     /**
@@ -683,7 +683,7 @@ class RequestResponseListenerTest extends PHPUnit_Framework_TestCase
     {
         $route = $this->getMockBuilder('Symfony\Component\Routing\Route')->disableOriginalConstructor()->getMock();
         $route->expects($this->exactly($times))->method('getOption')->will($this->returnValue($returnValue));
-        $routeCollection = $this->getMock('Symfony\Component\Routing\RouteCollection');
+        $routeCollection = $this->createMock('Symfony\Component\Routing\RouteCollection');
         $routeCollection->expects($this->exactly($times))->method('get')->will($this->returnValue($route));
 
         return $routeCollection;
@@ -701,7 +701,7 @@ class RequestResponseListenerTest extends PHPUnit_Framework_TestCase
     private function createGetResponseEvent($content, $method = 'GET', $headers = array())
     {
         $event = new GetResponseForControllerResultEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             $this->request,
             HttpKernelInterface::MASTER_REQUEST,
             $content
@@ -723,7 +723,7 @@ class RequestResponseListenerTest extends PHPUnit_Framework_TestCase
     private function createFilterResponseEvent($response, $method = 'GET', $headers = array())
     {
         $event = new FilterResponseEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             $this->request,
             HttpKernelInterface::MASTER_REQUEST,
             $response

--- a/Tests/Helper/DeviceViewTest.php
+++ b/Tests/Helper/DeviceViewTest.php
@@ -2,7 +2,7 @@
 
 namespace SunCat\MobileDetectBundle\Tests\Helper;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 /**
  * DeviceView Test
  */
-class DeviceViewTest extends PHPUnit_Framework_TestCase
+class DeviceViewTest extends TestCase
 {
 
     /**

--- a/Tests/Twig/Extension/MobileDetectExtensionTest.php
+++ b/Tests/Twig/Extension/MobileDetectExtensionTest.php
@@ -2,7 +2,7 @@
 
 namespace SunCat\MobileDetectBundle\Tests\Helper;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use SunCat\MobileDetectBundle\Helper\DeviceView;
 use SunCat\MobileDetectBundle\Twig\Extension\MobileDetectExtension;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 /**
  * DeviceView Test
  */
-class MobileDetectExtensionTest extends PHPUnit_Framework_TestCase
+class MobileDetectExtensionTest extends TestCase
 {
     /**
      * @var PHPUnit_Framework_MockObject_MockBuilder

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "twig/twig": "~1.26|~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0",
         "symfony/phpunit-bridge": "~2.7|~3.3",
         "satooshi/php-coveralls": "dev-master"
     },


### PR DESCRIPTION
* use `createMock()` instead of `getMock()` (which is deprecated)
* allow more compatible PHPUnit versions
* use the installed PHPUnit version instead of the global one shipped
  with Travis CI
* extend from the namespaced `TestCase` class (the PEAR-style like class
  is not available in PHPUnit 6)