### PR TITLE
Fix/symfony 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MobileDetectBundle
 =============
 
-Symfony 2.4.x-3.0.x bundle for detect mobile devices, manage mobile view and redirect to the mobile and tablet version.
+Symfony 2.4.x-4.0.x bundle for detect mobile devices, manage mobile view and redirect to the mobile and tablet version.
 
 [![Build Status](https://travis-ci.org/suncat2000/MobileDetectBundle.png?branch=master)](https://travis-ci.org/suncat2000/MobileDetectBundle) [![Latest Stable Version](https://poser.pugx.org/suncat/mobile-detect-bundle/v/stable.png)](https://packagist.org/packages/suncat/mobile-detect-bundle) [![Total Downloads](https://poser.pugx.org/suncat/mobile-detect-bundle/downloads.png)](https://packagist.org/packages/suncat/mobile-detect-bundle) [![Coverage Status](https://coveralls.io/repos/github/suncat2000/MobileDetectBundle/badge.svg?branch=master)](https://coveralls.io/github/suncat2000/MobileDetectBundle?branch=master)
 

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -27,7 +27,7 @@
             <call method="setRedirectConfig">
                 <argument>%mobile_detect.redirect%</argument>
             </call>
-            <tag name="data_collector" template="MobileDetectBundle:Collector:device" id="device.collector"/>
+            <tag name="data_collector" template="@MobileDetect/Collector/device.html.twig" id="device.collector"/>
         </service>
 
     </services>

--- a/Resources/views/Collector/device.html.twig
+++ b/Resources/views/Collector/device.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0",
         "symfony/phpunit-bridge": "~2.7|~3.3|~4.0",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "^2.0.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "suncat/mobile-detect-bundle",
-    "description": "Symfony2/3 bundle for detect mobile devices, managing mobile view types, redirect to mobile version.",
+    "description": "Symfony2/3/4 bundle for detect mobile devices, managing mobile view types, redirect to mobile version.",
     "keywords": ["mobile", "mobile detect", "symfony mobile", "mobile view managing", "mobile redirect"],
     "homepage": "https://github.com/suncat2000/MobileDetectBundle",
     "type": "symfony-bundle",


### PR DESCRIPTION
Added compatibility to Symfony4. There are other Pull Requests about this issue but none is passing the Travis tests and/or it seems there is no progress on the issue. Since we need this library to work on Symfony4 I'm making my own PR.

**Updates:**

- Updated bundle dependencies
- Change the way the `device.html.twig` is called on the listener.xml
- Readme/composer.json update adding support for Symfony4