### PR TITLE
Symfony 4.2 and 5.0 support

### DIFF
--- a/Helper/DeviceView.php
+++ b/Helper/DeviceView.php
@@ -33,6 +33,8 @@ class DeviceView
     const COOKIE_DOMAIN_DEFAULT                   = '';
     const COOKIE_SECURE_DEFAULT                   = false;
     const COOKIE_HTTP_ONLY_DEFAULT                = true;
+    const COOKIE_RAW_DEFAULT                      = false;
+    const COOKIE_SAMESITE_DEFAULT                 = null;
     const COOKIE_EXPIRE_DATETIME_MODIFIER_DEFAULT = '1 month';
     const SWITCH_PARAM_DEFAULT                    = 'device_view';
 
@@ -75,6 +77,16 @@ class DeviceView
      * @var bool
      */
     protected $cookieHttpOnly = self::COOKIE_HTTP_ONLY_DEFAULT;
+    
+    /**
+     * @var bool
+     */
+    protected $cookieRaw = self::COOKIE_RAW_DEFAULT;
+
+    /**
+     * @var string|null
+     */
+    protected $cookieSameSite = self::COOKIE_SAMESITE_DEFAULT;
 
     /**
      * @var string
@@ -416,6 +428,46 @@ class DeviceView
     }
 
     /**
+     * Is the cookie raw.
+     *
+     * @return bool
+     */
+    public function isCookieRaw()
+    {
+        return $this->cookieRaw;
+    }
+
+    /**
+     * Setter of CookieRaw.
+     *
+     * @param bool $cookieRaw
+     */
+    public function setCookieRaw($cookieRaw)
+    {
+        $this->cookieRaw = $cookieRaw;
+    }
+
+    /**
+     * Getter of CookieSamesite.
+     *
+     * @return string|null
+     */
+    public function getCookieSamesite()
+    {
+        return $this->cookieSamesite;
+    }
+
+    /**
+     * Setter of CookieSamesite.
+     *
+     * @param string|null $cookieSamesite
+     */
+    public function setCookieSamesite($cookieSamesite)
+    {
+        $this->cookieSamesite = $cookieSamesite;
+    }
+
+    /**
      * Setter of SwitchParam.
      *
      * @param string $switchParam
@@ -473,7 +525,9 @@ class DeviceView
             $this->getCookiePath(),
             $this->getCookieDomain(),
             $this->isCookieSecure(),
-            $this->isCookieHttpOnly()
+            $this->isCookieHttpOnly(),
+            $this->isCookieRaw(),
+            $this->getCookieSamesite()
         );
     }
 

--- a/Helper/DeviceView.php
+++ b/Helper/DeviceView.php
@@ -86,7 +86,7 @@ class DeviceView
     /**
      * @var string|null
      */
-    protected $cookieSameSite = self::COOKIE_SAMESITE_DEFAULT;
+    protected $cookieSamesite = self::COOKIE_SAMESITE_DEFAULT;
 
     /**
      * @var string


### PR DESCRIPTION
Creating a `new Cookie()` in SF4.2 triggers a deprecation notice, causing test suites to fail. The deprecation notice relates to the default value of two of the cookie constructor arguments. The notice suggests using the `Cookie::create()` method, but this is not available in Symfony versions older than 4.2. The alternative is to explicitly set values for all constructor arguments. This allows compatibility with older versions of Symfony while also supporting the newer versions in future.

```
The default value of the "$secure" and "$samesite" arguments of "Symfony\Component\HttpFoundation\Cookie::__construct"'s constructor will respectively change from "false" to "null" and from "null" to "lax" in Symfony 5.0, you should define their values explicitly or use "Cookie::create()" instead.
Stack trace:
#0 vendor/sentry/sentry/lib/Raven/ErrorHandler.php(127): Raven_Breadcrumbs_ErrorHandler->handleError(16384, 'The default val...', '/var/www/vendor...', 91, Array)
#1 [internal function]: Raven_ErrorHandler->handleError(16384, 'The default val...', '/var/www/vendor...', 91, Array)
#2 vendor/symfony/http-foundation/Cookie.php(91): trigger_error('The default val...', 16384)
#3 vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/Helper/DeviceView.php(476): Symfony\Component\HttpFoundation\Cookie->__construct('device_view', 'full', Object(DateTime), '/', '', false, true)
#4 vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/Helper/DeviceView.php(299): SunCat\MobileDetectBundle\Helper\DeviceView->createCookie('full')
#5 vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/EventListener/RequestResponseListener.php(219): SunCat\MobileDetectBundle\Helper\DeviceView->modifyResponse('full', Object(Symfony\Component\HttpFoundation\Response))
#6 vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/EventListener/RequestResponseListener.php(177): SunCat\MobileDetectBundle\EventListener\RequestResponseListener->SunCat\MobileDetectBundle\EventListener\{closure}(Object(SunCat\MobileDetectBundle\Helper\DeviceView), Object(Symfony\Component\HttpKernel\Event\FilterResponseEvent))
#7 vendor/symfony/event-dispatcher/EventDispatcher.php(212): SunCat\MobileDetectBundle\EventListener\RequestResponseListener->handleResponse(Object(Symfony\Component\HttpKernel\Event\FilterResponseEvent), 'kernel.response', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#8 vendor/symfony/event-dispatcher/EventDispatcher.php(44): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'kernel.response', Object(Symfony\Component\HttpKernel\Event\FilterResponseEvent))
#9 vendor/symfony/http-kernel/HttpKernel.php(189): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('kernel.response', Object(Symfony\Component\HttpKernel\Event\FilterResponseEvent))
#10 vendor/symfony/http-kernel/HttpKernel.php(171): Symfony\Component\HttpKernel\HttpKernel->filterResponse(Object(Symfony\Component\HttpFoundation\Response), Object(Symfony\Component\HttpFoundation\Request), 1)
#11 vendor/symfony/http-kernel/HttpKernel.php(67): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#12 vendor/symfony/http-kernel/Kernel.php(198): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#13 vendor/symfony/http-kernel/Client.php(68): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#14 vendor/symfony/framework-bundle/Client.php(131): Symfony\Component\HttpKernel\Client->doRequest(Object(Symfony\Component\HttpFoundation\Request))
#15 vendor/symfony/browser-kit/Client.php(405): Symfony\Bundle\FrameworkBundle\Client->doRequest(Object(Symfony\Component\HttpFoundation\Request))
#16 tests/functional/Bundle/QuizBundle/Controller/PublicControllerTest.php(13): Symfony\Component\BrowserKit\Client->request('GET', 'http://localhos...')
#17 [internal function]: Weirdly\Bundle\QuizBundle\Controller\PublicControllerTest->testPublicQuiz()
#18 {main}
Exited with code 1
```

This pull request introduces those arguments and sets them explicitly, maintaining current behaviour with no backwards-breaking changes.