### PR TITLE
TreeBuilder:root() deprecation fix

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,8 +29,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('mobile_detect');
+        $treeBuilder = new TreeBuilder('mobile_detect');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('mobile_detect');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix Deprecation Message in Symfony 4.3:

The **"Symfony\Component\Config\Definition\Builder\TreeBuilder::root()"** method called for the **"mobile_detect"** configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.