### PR TITLE
Fix deprecated use of Cookie

### DIFF
--- a/Helper/DeviceView.php
+++ b/Helper/DeviceView.php
@@ -518,7 +518,7 @@ class DeviceView
             $expire = new \Datetime(self::COOKIE_EXPIRE_DATETIME_MODIFIER_DEFAULT);
         }
 
-        return new Cookie(
+        return Cookie::create(
             $this->getCookieKey(),
             $value,
             $expire,


### PR DESCRIPTION
Fixes the deprecation warning:
```
The default value of the "$secure" and "$samesite" arguments of "Symfony\Component\HttpFoundation\Cookie::__construct"'s constructor will respectively change from "false" to "null" and from "null" to "lax" in Symfony 5.0, you should define their values explicitly or use "Cookie::create()" instead.
```