### PR TITLE
Fix composer Deprecation Notice

### DIFF
--- a/Tests/EventListener/RequestResponseListenerTest.php
+++ b/Tests/EventListener/RequestResponseListenerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SunCat\MobileDetectBundle\Tests\RequestListener;
+namespace SunCat\MobileDetectBundle\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;

--- a/Tests/Twig/Extension/MobileDetectExtensionTest.php
+++ b/Tests/Twig/Extension/MobileDetectExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SunCat\MobileDetectBundle\Tests\Helper;
+namespace SunCat\MobileDetectBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;


### PR DESCRIPTION
Deprecation Notice: Class SunCat\MobileDetectBundle\Tests\RequestListener\RequestResponseListenerTest located in ./vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/Tests/EventListener/RequestResponseListenerTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class SunCat\MobileDetectBundle\Tests\Helper\MobileDetectExtensionTest located in ./vendor/suncat/mobile-detect-bundle/SunCat/MobileDetectBundle/Tests/Twig/Extension/MobileDetectExtensionTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201